### PR TITLE
fix Tecplot2CFmesh and AeroCoef

### DIFF
--- a/cmake/macros/CFAddCompilationFlags.cmake
+++ b/cmake/macros/CFAddCompilationFlags.cmake
@@ -7,7 +7,7 @@ MACRO( CF_ADD_C_FLAGS m_c_flags )
     SET( N_CFLAG 0 )
   ENDIF()
 
- 	MATH ( EXPR N_CFLAG '${N_CFLAG}+1'  )    
+	MATH ( EXPR N_CFLAG "${N_CFLAG}+1"  )
 
   CHECK_C_COMPILER_FLAG ( ${m_c_flags} C_FLAG_TEST_${N_CFLAG} )
 
@@ -29,7 +29,7 @@ MACRO( CF_ADD_CXX_FLAGS m_cxx_flags )
     SET( N_CXXFLAG 0 )
   ENDIF()
 
- 	MATH ( EXPR N_CXXFLAG '${N_CXXFLAG}+1'  )    
+	MATH ( EXPR N_CXXFLAG "${N_CXXFLAG}+1"  )
 
   CHECK_CXX_COMPILER_FLAG ( ${m_cxx_flags} CXX_FLAG_TEST_${N_CXXFLAG} )
 

--- a/plugins/AeroCoef/Euler2DConsComputeAeroFVMCC.cxx
+++ b/plugins/AeroCoef/Euler2DConsComputeAeroFVMCC.cxx
@@ -431,7 +431,8 @@ void Euler2DConsComputeAeroFVMCC::prepareOutputFileAero()
 {
   CFAUTOTRACE;
 
-  boost::filesystem::path fpath (m_nameOutputFileAero);
+  using namespace boost::filesystem;
+  path fpath = Environment::DirPaths::getInstance().getResultsDir() / path ( m_nameOutputFileAero );
   fpath = PathAppender::getInstance().appendParallel( fpath );
 
   SelfRegistPtr<Environment::FileHandlerOutput> fhandle = Environment::SingleBehaviorFactory<Environment::FileHandlerOutput>::getInstance().create();
@@ -449,7 +450,8 @@ void Euler2DConsComputeAeroFVMCC::updateOutputFileAero()
 {
   CFAUTOTRACE;
 
-  boost::filesystem::path fpath (m_nameOutputFileAero);
+  using namespace boost::filesystem;
+  path fpath = Environment::DirPaths::getInstance().getResultsDir() / path ( m_nameOutputFileAero );
   fpath = PathAppender::getInstance().appendAllInfo( fpath );
 
   SelfRegistPtr<Environment::FileHandlerOutput> fhandle = Environment::SingleBehaviorFactory<Environment::FileHandlerOutput>::getInstance().create();

--- a/plugins/AeroCoef/EulerComputeAeroDG.cxx
+++ b/plugins/AeroCoef/EulerComputeAeroDG.cxx
@@ -539,7 +539,8 @@ void EulerComputeAeroDG::prepareOutputFileAero()
 {
   CFAUTOTRACE;
 
-  boost::filesystem::path fpath (m_nameOutputFileAero);
+  using namespace boost::filesystem;
+  path fpath = Environment::DirPaths::getInstance().getResultsDir() / path ( m_nameOutputFileAero );
   fpath = PathAppender::getInstance().appendParallel( fpath );
 
   SelfRegistPtr<Environment::FileHandlerOutput> fhandle = Environment::SingleBehaviorFactory<Environment::FileHandlerOutput>::getInstance().create();
@@ -557,7 +558,8 @@ void EulerComputeAeroDG::updateOutputFileAero()
 {
   CFAUTOTRACE;
 
-  boost::filesystem::path fpath (m_nameOutputFileAero);
+  using namespace boost::filesystem;
+  path fpath = Environment::DirPaths::getInstance().getResultsDir() / path ( m_nameOutputFileAero );
 //  fpath = PathAppender::getInstance().appendAllInfo( fpath );
 
   SelfRegistPtr<Environment::FileHandlerOutput> fhandle = Environment::SingleBehaviorFactory<Environment::FileHandlerOutput>::getInstance().create();

--- a/plugins/AeroCoef/EulerConsComputeAeroSpectralFD.cxx
+++ b/plugins/AeroCoef/EulerConsComputeAeroSpectralFD.cxx
@@ -646,7 +646,8 @@ void EulerConsComputeAeroSpectralFD::prepareOutputFileAero()
 
   const CFuint dim = PhysicalModelStack::getActive()->getDim();
 
-  boost::filesystem::path fpath (m_nameOutputFileAero);
+  using namespace boost::filesystem;
+  path fpath = Environment::DirPaths::getInstance().getResultsDir() / path ( m_nameOutputFileAero );
   fpath = PathAppender::getInstance().appendParallel( fpath );
 
   SelfRegistPtr<Environment::FileHandlerOutput> fhandle = Environment::SingleBehaviorFactory<Environment::FileHandlerOutput>::getInstance().create();
@@ -671,7 +672,8 @@ void EulerConsComputeAeroSpectralFD::updateOutputFileAero()
 {
   CFAUTOTRACE;
 
-  boost::filesystem::path fpath (m_nameOutputFileAero);
+  using namespace boost::filesystem;
+  path fpath = Environment::DirPaths::getInstance().getResultsDir() / path ( m_nameOutputFileAero );
   fpath = PathAppender::getInstance().appendParallel( fpath );
 
   SelfRegistPtr<Environment::FileHandlerOutput> fhandle = Environment::SingleBehaviorFactory<Environment::FileHandlerOutput>::getInstance().create();

--- a/plugins/AeroCoef/EulerConsComputeAeroSpectralFV.cxx
+++ b/plugins/AeroCoef/EulerConsComputeAeroSpectralFV.cxx
@@ -646,7 +646,8 @@ void EulerConsComputeAeroSpectralFV::prepareOutputFileAero()
 
   const CFuint dim = PhysicalModelStack::getActive()->getDim();
 
-  boost::filesystem::path fpath (m_nameOutputFileAero);
+  using namespace boost::filesystem;
+  path fpath = Environment::DirPaths::getInstance().getResultsDir() / path ( m_nameOutputFileAero );
   fpath = PathAppender::getInstance().appendParallel( fpath );
 
   SelfRegistPtr<Environment::FileHandlerOutput> fhandle = Environment::SingleBehaviorFactory<Environment::FileHandlerOutput>::getInstance().create();
@@ -671,7 +672,8 @@ void EulerConsComputeAeroSpectralFV::updateOutputFileAero()
 {
   CFAUTOTRACE;
 
-  boost::filesystem::path fpath (m_nameOutputFileAero);
+  using namespace boost::filesystem;
+  path fpath = Environment::DirPaths::getInstance().getResultsDir() / path ( m_nameOutputFileAero );
   fpath = PathAppender::getInstance().appendParallel( fpath );
 
   SelfRegistPtr<Environment::FileHandlerOutput> fhandle = Environment::SingleBehaviorFactory<Environment::FileHandlerOutput>::getInstance().create();

--- a/plugins/AeroCoef/NavierStokes2DConsComputeAero.cxx
+++ b/plugins/AeroCoef/NavierStokes2DConsComputeAero.cxx
@@ -999,7 +999,8 @@ void NavierStokes2DConsComputeAero::prepareOutputFileWall()
 
 void NavierStokes2DConsComputeAero::prepareOutputFileAero()
 {
-  boost::filesystem::path fpath = m_nameOutputFileAero;
+  using namespace boost::filesystem;
+  path fpath = Environment::DirPaths::getInstance().getResultsDir() / path ( m_nameOutputFileAero );
   fpath = PathAppender::getInstance().appendAllInfo(fpath, false, false);
 
   SelfRegistPtr<Environment::FileHandlerOutput> fhandle = Environment::SingleBehaviorFactory<Environment::FileHandlerOutput>::getInstance().create();
@@ -1022,7 +1023,8 @@ void NavierStokes2DConsComputeAero::prepareOutputFileAero()
 
 void NavierStokes2DConsComputeAero::updateOutputFileAero()
 {
-  boost::filesystem::path fpath (m_nameOutputFileAero);
+  using namespace boost::filesystem;
+  path fpath = Environment::DirPaths::getInstance().getResultsDir() / path ( m_nameOutputFileAero );
   fpath = PathAppender::getInstance().appendAllInfo( fpath, false, false);
 
   SelfRegistPtr<Environment::FileHandlerOutput> fhandle = Environment::SingleBehaviorFactory<Environment::FileHandlerOutput>::getInstance().create();

--- a/plugins/AeroCoef/NavierStokes2DConsComputeAeroHO.cxx
+++ b/plugins/AeroCoef/NavierStokes2DConsComputeAeroHO.cxx
@@ -1046,7 +1046,8 @@ void NavierStokes2DConsComputeAeroHO::prepareOutputFileWall()
 
 void NavierStokes2DConsComputeAeroHO::prepareOutputFileAero()
 {
-  boost::filesystem::path fpath = m_nameOutputFileAero;
+  using namespace boost::filesystem;
+  path fpath = Environment::DirPaths::getInstance().getResultsDir() / path ( m_nameOutputFileAero );
   fpath = PathAppender::getInstance().appendAllInfo(fpath, false, false);
 
   SelfRegistPtr<Environment::FileHandlerOutput> fhandle = Environment::SingleBehaviorFactory<Environment::FileHandlerOutput>::getInstance().create();
@@ -1070,7 +1071,8 @@ void NavierStokes2DConsComputeAeroHO::prepareOutputFileAero()
 
 void NavierStokes2DConsComputeAeroHO::updateOutputFileAero()
 {
-  boost::filesystem::path fpath (m_nameOutputFileAero);
+  using namespace boost::filesystem;
+  path fpath = Environment::DirPaths::getInstance().getResultsDir() / path ( m_nameOutputFileAero );
   fpath = PathAppender::getInstance().appendAllInfo( fpath, false, false);
 
   SelfRegistPtr<FileHandlerOutput> fhandle = Environment::SingleBehaviorFactory<FileHandlerOutput>::getInstance().create();

--- a/plugins/AeroCoef/NavierStokes2DConsComputeAeroHOIsoP2.cxx
+++ b/plugins/AeroCoef/NavierStokes2DConsComputeAeroHOIsoP2.cxx
@@ -608,7 +608,8 @@ void NavierStokes2DConsComputeAeroHOIsoP2::prepareOutputFileWall()
 
 void NavierStokes2DConsComputeAeroHOIsoP2::prepareOutputFileAero()
 {
-  boost::filesystem::path fpath = m_nameOutputFileAero;
+  using namespace boost::filesystem;
+  path fpath = Environment::DirPaths::getInstance().getResultsDir() / path ( m_nameOutputFileAero );
   fpath = PathAppender::getInstance().appendAllInfo(fpath, false, false);
 
   SelfRegistPtr<Environment::FileHandlerOutput> fhandle = Environment::SingleBehaviorFactory<Environment::FileHandlerOutput>::getInstance().create();
@@ -627,7 +628,8 @@ void NavierStokes2DConsComputeAeroHOIsoP2::prepareOutputFileAero()
 
 void NavierStokes2DConsComputeAeroHOIsoP2::updateOutputFileAero()
 {
-  boost::filesystem::path fpath (m_nameOutputFileAero);
+  using namespace boost::filesystem;
+  path fpath = Environment::DirPaths::getInstance().getResultsDir() / path ( m_nameOutputFileAero );
   fpath = PathAppender::getInstance().appendAllInfo( fpath, false, false);
 
   SelfRegistPtr<Environment::FileHandlerOutput> fhandle = Environment::SingleBehaviorFactory<Environment::FileHandlerOutput>::getInstance().create();

--- a/plugins/AeroCoef/NavierStokes3DConsComputeAero.cxx
+++ b/plugins/AeroCoef/NavierStokes3DConsComputeAero.cxx
@@ -862,7 +862,8 @@ void NavierStokes3DConsComputeAero::computeWall( bool saveWall, bool saveAero)
 
   if (writeAero) {
     cout << "Global aerodynamic coefficients: " << m_sumFMtotal << "    " << m_sumFMfric << "    " << m_sumFMpres << "\n" << flush;
-    boost::filesystem::path fpath = m_nameOutputFileAero;
+    using namespace boost::filesystem;
+    path fpath = Environment::DirPaths::getInstance().getResultsDir() / path ( m_nameOutputFileAero );
     fpath = PathAppender::getInstance().appendAllInfo(fpath, false, false, false);
     SelfRegistPtr<Environment::FileHandlerOutput> fhandle = Environment::SingleBehaviorFactory<Environment::FileHandlerOutput>::getInstance().create();
     ofstream& convergenceFile = fhandle->open(fpath,ios_base::app);
@@ -901,7 +902,8 @@ void NavierStokes3DConsComputeAero::prepareOutputFileWall()
 
 void NavierStokes3DConsComputeAero::prepareOutputFileAero()
 {
-  boost::filesystem::path fpath = m_nameOutputFileAero;
+  using namespace boost::filesystem;
+  path fpath = Environment::DirPaths::getInstance().getResultsDir() / path ( m_nameOutputFileAero );
   fpath = PathAppender::getInstance().appendAllInfo(fpath, false, false, false);
   SelfRegistPtr<Environment::FileHandlerOutput> fhandle = Environment::SingleBehaviorFactory<Environment::FileHandlerOutput>::getInstance().create();
   ofstream& convergenceFile = fhandle->open(fpath);

--- a/plugins/AeroCoef/NavierStokes3DConsComputeAeroHO.cxx
+++ b/plugins/AeroCoef/NavierStokes3DConsComputeAeroHO.cxx
@@ -1004,7 +1004,8 @@ void NavierStokes3DConsComputeAeroHO::prepareOutputFileWall()
 
 void NavierStokes3DConsComputeAeroHO::prepareOutputFileAero()
 {
-  boost::filesystem::path fpath = m_nameOutputFileAero;
+  using namespace boost::filesystem;
+  path fpath = Environment::DirPaths::getInstance().getResultsDir() / path ( m_nameOutputFileAero );
   fpath = PathAppender::getInstance().appendAllInfo(fpath, false, false);
 
   SelfRegistPtr<Environment::FileHandlerOutput> fhandle = Environment::SingleBehaviorFactory<Environment::FileHandlerOutput>::getInstance().create();
@@ -1028,7 +1029,8 @@ void NavierStokes3DConsComputeAeroHO::prepareOutputFileAero()
 
 void NavierStokes3DConsComputeAeroHO::updateOutputFileAero()
 {
-  boost::filesystem::path fpath (m_nameOutputFileAero);
+  using namespace boost::filesystem;
+  path fpath = Environment::DirPaths::getInstance().getResultsDir() / path ( m_nameOutputFileAero );
   fpath = PathAppender::getInstance().appendAllInfo( fpath, false, false);
 
   SelfRegistPtr<FileHandlerOutput> fhandle = Environment::SingleBehaviorFactory<FileHandlerOutput>::getInstance().create();

--- a/plugins/AeroCoef/NavierStokesComputeAeroDG.cxx
+++ b/plugins/AeroCoef/NavierStokesComputeAeroDG.cxx
@@ -593,7 +593,8 @@ void NavierStokesComputeAeroDG::prepareOutputFileAero()
 {
   CFAUTOTRACE;
 
-  boost::filesystem::path fpath (m_nameOutputFileAero);
+  using namespace boost::filesystem;
+  path fpath = Environment::DirPaths::getInstance().getResultsDir() / path ( m_nameOutputFileAero );
   fpath = PathAppender::getInstance().appendParallel( fpath );
 
   SelfRegistPtr<Environment::FileHandlerOutput> fhandle = Environment::SingleBehaviorFactory<Environment::FileHandlerOutput>::getInstance().create();
@@ -611,7 +612,8 @@ void NavierStokesComputeAeroDG::updateOutputFileAero()
 {
   CFAUTOTRACE;
 
-  boost::filesystem::path fpath (m_nameOutputFileAero);
+  using namespace boost::filesystem;
+  path fpath = Environment::DirPaths::getInstance().getResultsDir() / path ( m_nameOutputFileAero );
 //  fpath = PathAppender::getInstance().appendAllInfo( fpath );
 
   SelfRegistPtr<Environment::FileHandlerOutput> fhandle = Environment::SingleBehaviorFactory<Environment::FileHandlerOutput>::getInstance().create();

--- a/plugins/AeroCoef/NavierStokesConsComputeAero.cxx
+++ b/plugins/AeroCoef/NavierStokesConsComputeAero.cxx
@@ -704,7 +704,8 @@ boost::filesystem::path ( m_nameOutputFileWall );
 
 void NavierStokesConsComputeAero::prepareOutputFileAero()
 {
-  boost::filesystem::path fpath = m_nameOutputFileAero;
+  using namespace boost::filesystem;
+  path fpath = Environment::DirPaths::getInstance().getResultsDir() / path ( m_nameOutputFileAero );
   fpath = PathAppender::getInstance().appendAllInfo(fpath, false, false);
 
   SelfRegistPtr<Environment::FileHandlerOutput> fhandle = Environment::SingleBehaviorFactory<Environment::FileHandlerOutput>::getInstance().create();
@@ -721,7 +722,8 @@ void NavierStokesConsComputeAero::prepareOutputFileAero()
 
 void NavierStokesConsComputeAero::updateOutputFileAero()
 {
-  boost::filesystem::path fpath (m_nameOutputFileAero);
+  using namespace boost::filesystem;
+  path fpath = Environment::DirPaths::getInstance().getResultsDir() / path ( m_nameOutputFileAero );
   fpath = PathAppender::getInstance().appendAllInfo( fpath, false, false);
 
   SelfRegistPtr<Environment::FileHandlerOutput> fhandle = Environment::SingleBehaviorFactory<Environment::FileHandlerOutput>::getInstance().create();

--- a/plugins/AeroCoef/NavierStokesConsComputeAeroSpectralFD.cxx
+++ b/plugins/AeroCoef/NavierStokesConsComputeAeroSpectralFD.cxx
@@ -1220,7 +1220,8 @@ void NavierStokesConsComputeAeroSpectralFD::prepareOutputFileAero()
 
   const CFuint dim = PhysicalModelStack::getActive()->getDim();
 
-  boost::filesystem::path fpath (m_nameOutputFileAero);
+  using namespace boost::filesystem;
+  path fpath = Environment::DirPaths::getInstance().getResultsDir() / path ( m_nameOutputFileAero );
   fpath = PathAppender::getInstance().appendParallel( fpath );
 
   SelfRegistPtr<Environment::FileHandlerOutput> fhandle = Environment::SingleBehaviorFactory<Environment::FileHandlerOutput>::getInstance().create();
@@ -1245,7 +1246,8 @@ void NavierStokesConsComputeAeroSpectralFD::updateOutputFileAero()
 {
   CFAUTOTRACE;
 
-  boost::filesystem::path fpath (m_nameOutputFileAero);
+  using namespace boost::filesystem;
+  path fpath = Environment::DirPaths::getInstance().getResultsDir() / path ( m_nameOutputFileAero );
   fpath = PathAppender::getInstance().appendParallel( fpath );
 
   SelfRegistPtr<Environment::FileHandlerOutput> fhandle = Environment::SingleBehaviorFactory<Environment::FileHandlerOutput>::getInstance().create();

--- a/plugins/AeroCoef/NavierStokesConsComputeAeroSpectralFDCompact.cxx
+++ b/plugins/AeroCoef/NavierStokesConsComputeAeroSpectralFDCompact.cxx
@@ -852,7 +852,8 @@ void NavierStokesConsComputeAeroSpectralFDCompact::prepareOutputFileAero()
 
   const CFuint dim = PhysicalModelStack::getActive()->getDim();
 
-  boost::filesystem::path fpath (m_nameOutputFileAero);
+  using namespace boost::filesystem;
+  path fpath = Environment::DirPaths::getInstance().getResultsDir() / path ( m_nameOutputFileAero );
   fpath = PathAppender::getInstance().appendParallel( fpath );
 
   SelfRegistPtr<Environment::FileHandlerOutput> fhandle = Environment::SingleBehaviorFactory<Environment::FileHandlerOutput>::getInstance().create();
@@ -877,7 +878,8 @@ void NavierStokesConsComputeAeroSpectralFDCompact::updateOutputFileAero()
 {
   CFAUTOTRACE;
 
-  boost::filesystem::path fpath (m_nameOutputFileAero);
+  using namespace boost::filesystem;
+  path fpath = Environment::DirPaths::getInstance().getResultsDir() / path ( m_nameOutputFileAero );
   fpath = PathAppender::getInstance().appendParallel( fpath );
 
   SelfRegistPtr<Environment::FileHandlerOutput> fhandle = Environment::SingleBehaviorFactory<Environment::FileHandlerOutput>::getInstance().create();

--- a/plugins/Tecplot2CFmesh/Tecplot2CFmeshConverter.cxx
+++ b/plugins/Tecplot2CFmesh/Tecplot2CFmeshConverter.cxx
@@ -269,6 +269,11 @@ void Tecplot2CFmeshConverter::readZone(ifstream& fin,
     startData = fin.tellg();
     getTecplotWordsFromLine(fin, line, countl, words);
   }
+  //skip all auxdata
+  while (line.find("AUXDATA ") != string::npos) {
+    startData = fin.tellg();
+    getTecplotWordsFromLine(fin, line, countl, words);
+  }
   //  if the line contains "DT=" read it, otherwise go back because this is data to be stored 
   if (line.find("DT=") == string::npos) {
     fin.seekg(startData);
@@ -1041,8 +1046,14 @@ void Tecplot2CFmeshConverter::readVariables(ifstream& fin,
   getTecplotWordsFromLine(fin, line, lineNb, words); // VARIABLES
   
   while (line.find("ZONE") == string::npos) {
+    // skip line if the keywork "DATASETAUXDATA" is found
+    if (line.find("DATASETAUXDATA ") != string::npos) {
+    }
     // skip line if the keyword "FILETYPE" is found
-    if (line.find("FILETYPE") == string::npos) {
+    else if (line.find("FILETYPE") != string::npos) {
+    }
+    else {
+    // parse variable name
       for (CFuint i = 0; i < words.size(); ++i) {
 	if (words[i].find('=')==string::npos && words[i].find("VARIABLES")==string::npos) {
 	  CFLog(VERBOSE, "detected variable named <" << words[i] << "> \n");


### PR DESCRIPTION
AeroCoef:
Output File of coeficients should be in Results dir rather than current dir.

Tecplot2CFmesh:
Tecplot2CFmesh allow DATASETAUXDATA and AUXDATA now.
new tecplot maybe add some line such as DATASETAUXDATA or AUXDATA, old method may be in finite loop, however with this patch, Tecplot2CFmesh support DATASETAUXDATA and AUXDATA.